### PR TITLE
Fix ventanas sistema gestor aspirantes

### DIFF
--- a/app/src/main/AndroidManifest.xml
+++ b/app/src/main/AndroidManifest.xml
@@ -15,9 +15,9 @@
         android:theme="@style/Theme.WorkR"
         tools:targetApi="31">
         <activity
-            android:name=".Aspirants_Management_Screen"
+            android:name=".AspirantTrackingActivity"
             android:exported="false"
-            android:label="@string/title_activity_aspirants_management_screen"
+            android:label="@string/title_activity_aspirant_tracking_activity"
             android:theme="@style/Theme.WorkR" />
         <activity
             android:name=".List_vacanciesCompany"

--- a/app/src/main/java/com/example/workr/CompanyVacancyItem.kt
+++ b/app/src/main/java/com/example/workr/CompanyVacancyItem.kt
@@ -1,0 +1,64 @@
+package com.example.workr
+
+import android.content.Intent
+import androidx.compose.foundation.layout.Arrangement
+import androidx.compose.foundation.layout.Column
+import androidx.compose.foundation.layout.IntrinsicSize
+import androidx.compose.foundation.layout.Row
+import androidx.compose.foundation.layout.aspectRatio
+import androidx.compose.foundation.layout.fillMaxHeight
+import androidx.compose.foundation.layout.fillMaxWidth
+import androidx.compose.foundation.layout.height
+import androidx.compose.foundation.layout.padding
+import androidx.compose.material.icons.Icons
+import androidx.compose.material.icons.rounded.Info
+import androidx.compose.material3.Button
+import androidx.compose.material3.Icon
+import androidx.compose.material3.OutlinedButton
+import androidx.compose.material3.Text
+import androidx.compose.runtime.Composable
+import androidx.compose.ui.Modifier
+import androidx.compose.ui.platform.LocalContext
+import androidx.compose.ui.unit.dp
+
+/**
+ * Item listado de una vacante ofertada por una empresa en su lista propia.
+ * @param userId Id de referencia pasado en la navegación.
+ */
+@Composable
+fun CompanyVacancyItem(userId: String) {
+    val context = LocalContext.current
+
+    Row(
+        horizontalArrangement = Arrangement.spacedBy(8.dp),
+        modifier = Modifier.height(intrinsicSize = IntrinsicSize.Min).padding(vertical = 8.dp)
+    ) {
+        Icon(
+            Icons.Rounded.Info,
+            "Icono de vacante",
+            modifier = Modifier.fillMaxHeight().aspectRatio(1.0f)
+        )
+        Column {
+            Text("Nombre de la vacante")
+            Text("Ubicación")
+            Text("Publicado hace N días")
+            Row (
+                horizontalArrangement = Arrangement.SpaceAround,
+                modifier = Modifier.fillMaxWidth()
+            ) {
+                OutlinedButton(
+                    onClick = {}
+                ) {
+                    Text("Cerrar vacante")
+                }
+                Button(onClick = {
+                    val intent = Intent(context, AspirantTrackingActivity::class.java)
+                    intent.putExtra("user_id", userId)
+                    context.startActivity(intent)
+                }) {
+                    Text("Ver postulados")
+                }
+            }
+        }
+    }
+}

--- a/app/src/main/java/com/example/workr/Company_Vacancies_Screen.kt
+++ b/app/src/main/java/com/example/workr/Company_Vacancies_Screen.kt
@@ -1,0 +1,46 @@
+package com.example.workr
+
+import androidx.compose.foundation.layout.Column
+import androidx.compose.foundation.layout.fillMaxWidth
+import androidx.compose.foundation.lazy.LazyColumn
+import androidx.compose.material3.Text
+import androidx.compose.runtime.Composable
+import androidx.compose.ui.Modifier
+import androidx.compose.ui.text.style.TextAlign
+import androidx.compose.ui.unit.sp
+import androidx.navigation.NavHostController
+
+/**
+ * Ventana que lista las vacantes ofertadas por la empresa propia.
+ * @param globalNavController Controlador de la navegación de la barra superior.
+ * @param loginType Tipo de login diferenciando al usuario de empresa que revisa
+ * su lista de vacantes, para mostrar la barra superior apropiada.
+ * @param userId Id de referencia pasado en la navegación.
+ */
+@Composable
+fun CompanyVacanciesScreen(
+    globalNavController: NavHostController,
+    loginType: String,
+    userId: String
+) {
+    WorkRScaffold(
+        navController = globalNavController,
+        loginType = loginType
+    ) { innerPadding ->
+        Column {
+            Text(
+                "Vacantes activas",
+                fontSize = 32.sp,
+                textAlign = TextAlign.Center,
+                modifier = Modifier.fillMaxWidth()
+            )
+            LazyColumn (
+                modifier = Modifier.weight(1.0f)
+            ) {
+                items (10) { item ->
+                    CompanyVacancyItem(userId = userId)
+                }
+            }
+        }
+    }
+}

--- a/app/src/main/java/com/example/workr/PostulationFormScreen.kt
+++ b/app/src/main/java/com/example/workr/PostulationFormScreen.kt
@@ -49,10 +49,12 @@ fun PostulacionFormScreen(
     val portafolio = remember { mutableStateOf("") }
 
     val fieldsEnabled = (fromAspirantsTrackingList == null)
+    val aspirantTrackingListMode = fromAspirantsTrackingList != null
 
     WorkRScaffold(
         navController = navController,
         loginType = loginType,
+        fromAspirantsTrackingList = aspirantTrackingListMode
     ) { innerPadding ->
 
         Box(
@@ -65,10 +67,12 @@ fun PostulacionFormScreen(
                 val height = size.height
                 val cornerSize = 80.dp.toPx()
 
-                drawRect(
-                    color = Color(0xFF0078C1),
-                    size = Size(width, 60.dp.toPx())
-                )
+                if (!aspirantTrackingListMode) {
+                    drawRect(
+                        color = Color(0xFF0078C1),
+                        size = Size(width, 60.dp.toPx())
+                    )
+                }
 
                 val pathLeft = Path().apply {
                     moveTo(0f, height - cornerSize)
@@ -119,7 +123,7 @@ fun PostulacionFormScreen(
 
                 Spacer(modifier = Modifier.height(24.dp))
 
-                if (fromAspirantsTrackingList == null) {
+                if (!aspirantTrackingListMode) {
                     Button(
                         onClick = { /* Acción al enviar */ },
                         modifier = Modifier

--- a/app/src/main/java/com/example/workr/WorkRTopBar.kt
+++ b/app/src/main/java/com/example/workr/WorkRTopBar.kt
@@ -20,11 +20,14 @@ import androidx.navigation.compose.currentBackStackEntryAsState
 fun WorkRScaffold(
     navController: NavHostController,
     loginType: String,
+    fromAspirantsTrackingList: Boolean = false,
     content: @Composable (PaddingValues) -> Unit
 ) {
     Scaffold(
         topBar = {
-            WorkRTopBar(navController = navController, loginType = loginType)
+            if (!fromAspirantsTrackingList) {
+                WorkRTopBar(navController = navController, loginType = loginType)
+            }
         }
     ) { innerPadding ->
         Box(modifier = Modifier.padding(innerPadding)) {
@@ -51,9 +54,9 @@ fun WorkRTopBar(
                 "Perfil"
             ),
             Triple(
-                if (isEmpleado) "company_listing" else "aspirant_tracking_system",
+                if (isEmpleado) "company_listing" else "company_vacancies",
                 if (isEmpleado) R.drawable.ic_jobs else R.drawable.ic_postulations,
-                if (isEmpleado) "Empleos" else "Gestión de Aspirantes"
+                if (isEmpleado) "Empleos" else "Vacantes de empresa"
             ),
             Triple("virtual_office", R.drawable.ic_virtual_office, "Oficina Virtual"),
             Triple("notifications", R.drawable.ic_notifications, "Notificaciones")

--- a/app/src/main/java/com/example/workr/navigation/WorkRNavGraph.kt
+++ b/app/src/main/java/com/example/workr/navigation/WorkRNavGraph.kt
@@ -100,24 +100,6 @@ fun WorkRApp(loginViewModel: LoginViewModel = viewModel()) {
             )
         }
 
-        composable("initial_aspirant_postulation_form") {
-            PostulacionFormScreen(
-                navController = navController,
-                loginType = loginType,
-                userId = userId,
-                fromAspirantsTrackingList = "initial"
-            )
-        }
-
-        composable("contacted_aspirant_postulation_form") {
-            PostulacionFormScreen(
-                navController = navController,
-                loginType = loginType,
-                userId = userId,
-                fromAspirantsTrackingList = "contacted"
-            )
-        }
-
         composable("company_listing") {
             CompanyListing(
                 navController = navController,
@@ -174,16 +156,12 @@ fun WorkRApp(loginViewModel: LoginViewModel = viewModel()) {
             )
         }
 
-        composable("aspirant_tracking_system") {
-            AspirantTrackingScreen(
+        composable("company_vacancies") {
+            CompanyVacanciesScreen(
                 globalNavController = navController,
                 loginType = loginType,
                 userId = userId
             )
-        }
-
-        composable("interview_notes") {
-            InterviewNotesScreen(navController = navController)
         }
     }
 }

--- a/app/src/main/res/values/strings.xml
+++ b/app/src/main/res/values/strings.xml
@@ -7,5 +7,5 @@
     <string name="title_activity_company_listing">Company_Listing</string>
     <string name="title_activity_complete_perfile_bussiness">Complete_Perfile_Bussiness</string>
     <string name="title_activity_list_vacancies_company">List_vacanciesCompany</string>
-    <string name="title_activity_aspirants_management_screen">Aspirants_Management_Screen</string>
+    <string name="title_activity_aspirant_tracking_activity">AspirantTrackingActivity</string>
 </resources>


### PR DESCRIPTION
# Corregido acceso al sistema gestor de aspirantes
Se observó que faltaba una ventana para dar acceso al sistema gestor de aspirantes desde un listado de vacantes de la empresa propia, esta rama agrega dicha ventana y corrige la navegación hacia y dentro del SGA

## Novedades
- Nueva ventana y componente de lista para el listado de vacantes de la empresa propia
- Nueva activity que ahora contiene al sistema gestor de aspirantes y le da navegación interna

## Cambios
- Se ajustó la ventana del formulario de postulación para volver a ocultar la barra superior si se accede desde el SGA
- Se ajustó la ruta referenciada en la top bar del WorkRScaffold para que apunte a la nueva ventana del listado de vacantes
- Se agregó un parámetro opcional al WorkRScaffold para que se pueda ocultar la barra superior desde el SGA
- Se movieron las rutas de navegación del SGA desde la navegación global a una navegación interna en la nueva activity