### PR TITLE
Configurado JWT de login en request default del HTTP Client

### DIFF
--- a/app/src/main/java/com/example/workr/HTTPClientAPI.kt
+++ b/app/src/main/java/com/example/workr/HTTPClientAPI.kt
@@ -31,6 +31,16 @@ object HTTPClientAPI {
     private val BACKEND_BASE_URL = BuildConfig.BACKEND_BASE_URL
     private val BACKEND_API_KEY = BuildConfig.BACKEND_API_KEY
 
+    private var jwt: String? = null
+
+    /**
+     * Configura el JWT a usar en las requests.
+     * @param jwt JWT que se usará para autenticación de las requests.
+     */
+    fun setJwt(jwt: String) {
+        this.jwt = jwt
+    }
+
     /**
      * Realiza una solicitud HTTP al endpoint especificado del backend.
      * @param endpoint Endpoint al que se hará la solicitud.
@@ -52,6 +62,9 @@ object HTTPClientAPI {
             }
             // Se agrega la api key del backend por defecto a toda solicitud.
             install(DefaultRequest) {
+                if (jwt != null) {
+                    header(HttpHeaders.Authorization, "Bearer $jwt")
+                }
                 header("Api-Key", BACKEND_API_KEY)
             }
         }
@@ -122,6 +135,9 @@ object HTTPClientAPI {
             }
             // Se agrega la api key del backend por defecto a toda solicitud.
             install(DefaultRequest) {
+                if (jwt != null) {
+                    header(HttpHeaders.Authorization, "Bearer $jwt")
+                }
                 header("Api-Key", BACKEND_API_KEY)
             }
         }

--- a/app/src/main/java/com/example/workr/Login.kt
+++ b/app/src/main/java/com/example/workr/Login.kt
@@ -112,6 +112,9 @@ fun LoginScreen(
                                         val sharedPref = navController.context.getSharedPreferences("auth_prefs", android.content.Context.MODE_PRIVATE)
                                         sharedPref.edit().putString("jwt", loginResponse.jwt).apply()
 
+                                        // Se establece el jwt para uso por defecto en el HTTPClientAPI.
+                                        HTTPClientAPI.setJwt(loginResponse.jwt)
+
                                         Toast.makeText(
                                             navController.context,
                                             "Login exitoso: ${loginResponse.loginType}",

--- a/app/src/main/java/com/example/workr/PostulationFormScreen.kt
+++ b/app/src/main/java/com/example/workr/PostulationFormScreen.kt
@@ -47,7 +47,6 @@ fun PostulacionFormScreen(
     val herramientas = remember { mutableStateOf("") }
     val razonIngreso = remember { mutableStateOf("") }
     val portafolio = remember { mutableStateOf("") }
-    val aspirantTrackingListMode = fromAspirantsTrackingList != null
 
     val fieldsEnabled = (fromAspirantsTrackingList == null)
     val aspirantTrackingListMode = fromAspirantsTrackingList != null


### PR DESCRIPTION
# Uso del JWT del login por defecto en HTTP Client
Con esta rama ahora el HTTPClientAPI recibirá el JWT obtenido de un Login exitoso y lo usará en todas las requests.

## Novedades
- Método del HTTPClientAPI para establecer el JWT

## Cambios
- Ahora el login exitoso configura el JWT en el HTTPClientAPI
- Eliminada línea duplicada con error en el formulario de postulación